### PR TITLE
CSS 1045 Fix CW tags

### DIFF
--- a/iam.main.tf
+++ b/iam.main.tf
@@ -171,6 +171,8 @@ resource "aws_iam_role_policy" "ConsoleTaskPolicy" {
           "logs:GetQueryResults",
           "logs:PutLogEvents",
           "logs:*Query",
+          "logs:ListTagsForResource",
+          "logs:TagResource",
           "s3:CreateBucket",
           "s3:GetBucket*",
           "s3:Get*Configuration",


### PR DESCRIPTION
Add a couple of permissions required for CF to update Stack related resources.
Not really required for terraform, but for the sake of consistency.